### PR TITLE
German translation & a more flexible amount parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ A video tutorial is available here https://www.youtube.com/watch?v=F_DSCm1LjIw
 
 ## Install & Run
 
-To install the desktop version of Fortunæ in Windows and Linux:
+To install Fortunæ in Windows and Linux:
 
 ```
 git clone https://github.com/uonai/Fortunae
-cd Fortunae/desktop/
+cd Fortunae
 npm install
 npm start
 ```
 
 ## Localization
 
-Fortunae is available in English and Spanish. To toggle language, navigate to the settings using ctrl + 6.
+Fortunae is available in English, Spanish and German. To toggle language, navigate to the settings using ctrl + 6.
 
 ## Theming
 
@@ -58,7 +58,7 @@ If combined total of Savings and Emergency Fund is less than or equal to 3x the 
 
 #### General Setup
 
-You should decide between whether you are tracking your finances weekly or monthly and adhere to this. Each record will reperesent that time frame and it will make record keeping dependable.
+You should decide between whether you are tracking your finances weekly or monthly and adhere to this. Each record will represent that time frame and it will make record keeping dependable.
 
 #### Funds
 

--- a/client/js/app.js
+++ b/client/js/app.js
@@ -240,10 +240,10 @@ function doc_keyUp(e) {
       console.log("4");
     } else if (e.ctrlKey && e.keyCode == 53) {
       BudgetModal.showModal(e);
-      console.log("4");
+      console.log("5");
     } else if (e.ctrlKey && e.keyCode == 54) {
       SettingsModal.showEditItemModal(e);
-      console.log("4");
+      console.log("6");
     }
   }
   if (e.key == "Escape") {

--- a/client/js/components/modals/budgetModal.js
+++ b/client/js/components/modals/budgetModal.js
@@ -89,11 +89,12 @@ export default class BudgetModal {
 
   static validate(action) {
     const title = document.querySelector("#form-calculator-title").value;
-    const amount = document.querySelector("#form-calculator-amount").value;
     const category = document.querySelector("#form-calculator-category").value;
     const type = document.querySelector("#form-calculator-type").value;
     const alertText = "Please fill out all form fields.";
     const numberAlertText = "Please enter valid number";
+    const localizedAmount = document.querySelector("#form-calculator-amount").value;
+    const amount = Language.delocalizeAmount(localizedAmount);
 
     if (title === "" || amount === "" || type === "Category") {
       UI.showAlert(alertText);

--- a/client/js/components/modals/debtModal.js
+++ b/client/js/components/modals/debtModal.js
@@ -88,11 +88,12 @@ export default class DebtModal {
 
   static validate(action) {
     const title = document.querySelector("#form-calculator-title").value;
-    const amount = document.querySelector("#form-calculator-amount").value;
     const category = document.querySelector("#form-calculator-category").value;
     const type = document.querySelector("#form-calculator-type").value;
     const alertText = "Please fill out all form fields.";
     const numberAlertText = "Please enter valid number";
+    const localizedAmount = document.querySelector("#form-calculator-amount").value;
+    const amount = Language.delocalizeAmount(localizedAmount);
 
     if (title === "" || amount === "" || type === "Category") {
       UI.showAlert(alertText);

--- a/client/js/components/modals/expenseModal.js
+++ b/client/js/components/modals/expenseModal.js
@@ -88,11 +88,12 @@ export default class ExpenseModal {
 
   static validate(action) {
     const title = document.querySelector("#form-calculator-title").value;
-    const amount = document.querySelector("#form-calculator-amount").value;
     const category = document.querySelector("#form-calculator-category").value;
     const type = document.querySelector("#form-calculator-type").value;
     const alertText = "Please fill out all form fields.";
     const numberAlertText = "Please enter valid number";
+    const localizedAmount = document.querySelector("#form-calculator-amount").value;
+    const amount = Language.delocalizeAmount(localizedAmount);
 
     if (title === "" || amount === "" || type === "Category") {
       UI.showAlert(alertText);

--- a/client/js/components/modals/fundModal.js
+++ b/client/js/components/modals/fundModal.js
@@ -87,11 +87,13 @@ export default class FundModal {
 
   static validate(action) {
     const title = document.querySelector("#form-calculator-title").value;
-    const amount = document.querySelector("#form-calculator-amount").value;
     const category = document.querySelector("#form-calculator-category").value;
     const type = document.querySelector("#form-calculator-type").value;
     const alertText = "Please fill out all form fields.";
     const numberAlertText = "Please enter valid number";
+    const localizedAmount = document.querySelector("#form-calculator-amount").value;
+    const amount = Language.delocalizeAmount(localizedAmount);
+
     if (title === "" || amount === "" || type === "Category") {
       UI.showAlert(alertText);
     } else if (!Number(amount)) {

--- a/client/js/components/modals/incomeModal.js
+++ b/client/js/components/modals/incomeModal.js
@@ -88,11 +88,12 @@ export default class IncomeModal {
 
   static validate(action) {
     const title = document.querySelector("#form-calculator-title").value;
-    const amount = document.querySelector("#form-calculator-amount").value;
     const category = document.querySelector("#form-calculator-category").value;
     const type = document.querySelector("#form-calculator-type").value;
     const alertText = "Please fill out all form fields.";
     const numberAlertText = "Please enter valid number";
+    const localizedAmount = document.querySelector("#form-calculator-amount").value;
+    const amount = Language.delocalizeAmount(localizedAmount);
 
     if (title === "" || amount === "" || type === "Category") {
       UI.showAlert(alertText);

--- a/client/js/utils/language.js
+++ b/client/js/utils/language.js
@@ -10,4 +10,15 @@ export default class Language {
     let locale = JSON.parse(localStorage.getItem("language"));
     return locale[category];
   }
+
+  // Remove all language specific parts from an amount and replace it with the
+  // correct character, so it can be handled like a float later on. This allows
+  // to insert strings like "1,99 EUR" or "$ 1,000.90".
+  static delocalizeAmount(str) {
+    let decimalPoint = Language.getTerminology('time', 'decimal');
+    return str
+      .replace(decimalPoint, '.') // Convert all language specific decimal points
+      .replace(/[^0-9\.-]/g, '');  // Remove all not needed characters like a $ sign.
+  }
 }
+

--- a/language/de-de.json
+++ b/language/de-de.json
@@ -1,0 +1,164 @@
+{
+  "general": {
+    "save": "Speichern",
+    "clone": "Duplizieren",
+    "delete": "Löschen",
+    "edit": "Bearbeiten",
+    "saveEdits": "Änderungen speichern",
+    "saveNew": "Speichern",
+    "cancel": "Abbrechen",
+    "title": "Titel",
+    "amount": "Betrag",
+    "total": "Summe",
+    "recommendations": "Empfehlungen",
+    "trendData": "Trendkurve",
+    "history": "Historie",
+    "tome": "Dokumentation",
+    "noDataAvailable": "Keine Daten verfügbar",
+    "recordSaved": "Eintrag wurde gespeichert",
+    "recordCloned": "Eintrag wurde dupliziert",
+    "recordSelected": "Neuer historischer Eintrag markiert",
+    "recordDeleted": "Eintrag wurde gelöscht",
+    "confirm": "Ja",
+    "deny": "Nein"
+  },
+  "delete": {
+    "confirmation": "Sicher?",
+    "confirmationSubtext": "Eintrag wird unwiederruflich gelöscht."
+  },
+  "time": {
+    "decimal": ",",
+    "thousands": ".",
+    "grouping": [3],
+    "currency": ["€", ""],
+    "dateTime": "%a %b %e %X %Y",
+    "date": "%d.%m.%Y",
+    "time": "%H:%M:%S",
+    "periods": ["AM", "PM"],
+    "days": [
+      "Montag",
+      "Dienstag",
+      "Mittwoch",
+      "Donnerstag",
+      "Freitag",
+      "Samstag",
+      "Sonntag"
+    ],
+    "shortDays": ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"],
+    "months": [
+      "Januar",
+      "Februar",
+      "März",
+      "April",
+      "Mai",
+      "Juni",
+      "Juli",
+      "August",
+      "September",
+      "Oktober",
+      "November",
+      "Dezember"
+    ],
+    "shortMonths": [
+      "Jan",
+      "Feb",
+      "Mär",
+      "Apr",
+      "Mai",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Okt",
+      "Nov",
+      "Dez"
+    ]
+  },
+  "fund": {
+    "title": "Erspartes",
+    "categories": {
+      "category": "Kategorie",
+      "checking": "Rücklage",
+      "saving": "Erspartes",
+      "investment": "Investition",
+      "emergency": "Notfall"
+    },
+    "addItem": "Hinzufügen",
+    "modalTitle": "Erspartes hinzufügen",
+    "editItem": "Erspartes editieren"
+  },
+  "expense": {
+    "title": "Ausgaben",
+    "savings": "Rücklagen",
+    "categories": {
+      "category": "Kategorie",
+      "autoAndTransport": "Auto & Transport",
+      "billsAndUtilities": "Rechnungen & Nebenkosten",
+      "businessServices": "Dienstleistungen",
+      "education": "Weiterbildung",
+      "feesAndCharges": "Gebühren & Daueraufträge",
+      "foodAndDining": "Essen",
+      "giftsAndDonations": "Geschenke & Spenden",
+      "healthAndFitness": "Gesundheit & Fitness",
+      "investments": "Anschaffungen",
+      "miscExpense": "Sonstiges",
+      "personalCare": "Persönlich",
+      "savings": "Rücklagen",
+      "shopping": "Einkaufen",
+      "taxes": "Steuern"
+    },
+    "addItem": "Hinzufügen",
+    "modalTitle": "Ausgaben hinzufügen",
+    "editItem": "Ausgaben bearbeiten"
+  },
+  "budget": {
+    "title": "Finanzplan",
+    "categories": {
+      "category": "Kategorie",
+      "wants": "Gewünscht",
+      "needs": "Benötigt"
+    },
+    "addItem": "Hinzufügen",
+    "modalTitle": "Etwas finanzieren",
+    "editItem": "Bearbeiten"
+  },
+  "debt": {
+    "title": "Schulden",
+    "categories": {
+      "category": "Kategorie",
+      "secured": "Versichert",
+      "unsecured": "Unversichert"
+    },
+    "addItem": "Hinzufügen",
+    "modalTitle": "Schulden hinzufügen",
+    "editItem": "Bearbeiten"
+  },
+  "income": {
+    "title": "Einnahmen",
+    "categories": {
+      "category": "Kategorie",
+      "active": "Aktiv",
+      "passive": "Passiv",
+      "portfolio": "Anlage"
+    },
+    "addItem": "Hinzufügen",
+    "modalTitle": "Einnahmen hinzufügen",
+    "editItem": "Bearbeiten"
+  },
+  "recommendation": {
+    "save": "Rücklagen bilden",
+    "spend": "Für Ausgaben",
+    "invest": "Investiere",
+    "emergencyFund": "Sicherheitsücklage",
+    "needSourceOfIncome": "Weitere Einnahmequelle wird benötigt"
+  },
+  "settings": {
+    "title": "Einstellungen",
+    "foreground": "Vordergrund",
+    "background": "Hintergrund",
+    "alert": "Alarm",
+    "confirmation": "Bestätigung",
+    "language": "Language",
+    "editItem": "Einstellungen bearbeiten"
+  }
+}


### PR DESCRIPTION
Adding German translation. On the way, I realized that amounts will be
separated with the . (dot) sign. This is right for the US, but other
countries/languages use other symbols as a separator. The translation
file already handle this, but the code was not ready to handle amounts
with , (comma) or an EUR symbol at the end. For that, there is a new
helper method, which will transform the input string (an maybe localized
amount) to a valid float, so it can be used to do calculations.

On the way I've cleaned up some typos.