### PR TITLE
Spelling adjustment & modify default dev tools behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 client/db
+dist
+.DS_Store

--- a/language/en-us.json
+++ b/language/en-us.json
@@ -5,7 +5,7 @@
     "delete": "Delete",
     "edit": "Edit",
     "saveEdits": "Save Edits",
-    "saveNew": "Save Newx",
+    "saveNew": "Save New",
     "cancel": "Cancel",
     "title": "Title",
     "amount": "Amount",

--- a/main.js
+++ b/main.js
@@ -36,7 +36,6 @@ function createWindow() {
   );
 
   // Open the DevTools.
-  mainWindow.webContents.openDevTools();
   mainWindow.setMenuBarVisibility(false);
 }
 


### PR DESCRIPTION
* Don't open devtools by default
Still accessible with keyboard shortcuts for debugging. Even better might be to only open it automatically if running under `npm start`.

* Add `dist`, `.DS_Store` to gitignore.
Ignore build artifacts and macOS folder metadata files.

* Remove typo in the string "Save New"

This is looking like an awesome tool. Thanks for making it open source!