### PR TITLE
@jordattebayo/theming updates

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -22,6 +22,7 @@
 * {
   box-sizing: border-box;
   color: var(--foreground-color);
+  fill: var(--foreground-color);
   font-family: "Roboto Mono", monospace;
   line-height: 1.8;
   margin: 0;

--- a/settings.json
+++ b/settings.json
@@ -1,1 +1,1 @@
-{"language":"en-us","foregroundColor":"#fff","backgroundColor":"#000","alertColor":"#ffb545","confirmationColor":"#fff"}
+{"language":"en-us","foregroundColor":"#fff","backgroundColor":"#000","alertColor":"#ffb545","confirmationColor":"#000"}

--- a/settings.json
+++ b/settings.json
@@ -1,1 +1,1 @@
-{"language":"en-us","foregroundColor":"#fff","backgroundColor":"#000","alertColor":"#ffb545","confirmationColor":"#000"}
+{"language":"en-us","foregroundColor":"#fff","backgroundColor":"#000","alertColor":"#ffb545","confirmationColor":"#fff"}


### PR DESCRIPTION
The income and expense pop out charts were dependent on the inherited body styling. The body styling did not have a fill property and only used the color property. As a result some of the SVG elements were using the default fill properties which caused them to not be visible against dark backgrounds. Adding the fill property in the body styling enabled the SVG elements to inherit the var(--foreground-color). 

![Fortunae_dark](https://user-images.githubusercontent.com/31581758/87574263-28354900-c69c-11ea-96bc-ab13a58cc778.JPG)

![Fortunae_light](https://user-images.githubusercontent.com/31581758/87574265-28cddf80-c69c-11ea-8f52-86ea23063198.JPG)
